### PR TITLE
Make AppVeyor build succeed

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 build_script:
   - echo | install-tl-windows.bat -v -profile=texlive.profile
+  - set PATH=%PATH%;C:\texlive\bin\win32
 
 test_script:
   - tlmgr --version

--- a/texlive.profile
+++ b/texlive.profile
@@ -1,1 +1,4 @@
 selected_scheme scheme-infraonly
+TEXDIR C:\texlive
+option_doc 0
+option_src 0


### PR DESCRIPTION
This pull request standardizes TEXDIR and adds it to the Windows PATH so that tlmgr is found and the AppVeyor [build succeeds](https://ci.appveyor.com/project/nwhetsell/installer/build/1.0.1). (It also modifies texlive.profile so that documentation and source files aren’t downloaded on AppVeyor.)