### PR TITLE
Use Travis CI to test installing on Linux and macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ os:
   - osx
 
 before_script:
-  - echo 'TEXDIR /usr/local/texlive' >> texlive.profile
+  - echo -e "selected_scheme scheme-infraonly\nTEXDIR /usr/local/texlive\noption_doc 0\noption_src 0" > texlive.profile
 
 script:
-  - ./install-tl -profile=texlive.profile
+  - sudo ./install-tl -profile=texlive.profile
   - PATH=$PATH:/usr/local/texlive/bin/x86_64-$(if [ $TRAVIS_OS_NAME == 'osx' ]; then echo darwin; else echo linux; fi)
   - tlmgr --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: generic
+
+os:
+  - linux
+  - osx
+
+before_script:
+  - echo 'TEXDIR /usr/local/texlive' >> texlive.profile
+
+script:
+  - ./install-tl -profile=texlive.profile
+  - PATH=$PATH:/usr/local/texlive/bin/x86_64-$(if [ $TRAVIS_OS_NAME == 'osx' ]; then echo darwin; else echo linux; fi)
+  - tlmgr --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 before_build:
-  - echo "TEXDIR C:\texlive" >> texlive.profile
+  - echo TEXDIR C:\texlive >> texlive.profile
 
 build_script:
   - echo | install-tl-windows.bat -v -profile=texlive.profile

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 before_build:
+  - where tar
   - ps: Start-FileDownload 'http://mirror.ctan.org/systems/texlive/tlnet/install-tl.zip'
   - 7z x install-tl.zip
   - cd install-tl-20*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 before_build:
-  - echo TEXDIR C:\texlive >> texlive.profile
+  - ps: Set-Content texlive.profile "selected_scheme scheme-infraonly`nTEXDIR C:\texlive`noption_doc 0`noption_src 0`n"
 
 build_script:
   - echo | install-tl-windows.bat -v -profile=texlive.profile

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 before_build:
-  - ps: Set-Content texlive.profile "selected_scheme scheme-infraonly`nTEXDIR C:\texlive`noption_doc 0`noption_src 0`n"
+  - ps: Set-Content texlive.profile "selected_scheme scheme-minimal`nTEXDIR C:\texlive`noption_doc 0`noption_src 0`n"
 
 build_script:
   - echo | install-tl-windows.bat -v -profile=texlive.profile

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,5 @@
 before_build:
-  - where tar
-  - ps: Start-FileDownload 'http://mirror.ctan.org/systems/texlive/tlnet/install-tl.zip'
-  - 7z x install-tl.zip
-  - cd install-tl-20*
-  - ps: Set-Content texlive.profile "selected_scheme scheme-minimal`nTEXDIR C:\texlive`noption_doc 0`noption_src 0`n"
+  - ps: Set-Content texlive.profile "selected_scheme scheme-infraonly`nTEXDIR C:\texlive`noption_doc 0`noption_src 0`n"
 
 build_script:
   - echo | install-tl-windows.bat -v -profile=texlive.profile

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,6 @@
+before_build:
+  - echo "TEXDIR C:\texlive" >> texlive.profile
+
 build_script:
   - echo | install-tl-windows.bat -v -profile=texlive.profile
   - set PATH=%PATH%;C:\texlive\bin\win32

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,7 @@
 before_build:
+  - ps: Start-FileDownload 'http://mirror.ctan.org/systems/texlive/tlnet/install-tl.zip'
+  - 7z x install-tl.zip
+  - cd install-tl-20*
   - ps: Set-Content texlive.profile "selected_scheme scheme-minimal`nTEXDIR C:\texlive`noption_doc 0`noption_src 0`n"
 
 build_script:

--- a/texlive.profile
+++ b/texlive.profile
@@ -1,3 +1,0 @@
-selected_scheme scheme-infraonly
-option_doc 0
-option_src 0

--- a/texlive.profile
+++ b/texlive.profile
@@ -1,4 +1,3 @@
 selected_scheme scheme-infraonly
-TEXDIR C:\texlive
 option_doc 0
 option_src 0


### PR DESCRIPTION
This pull request adds minimal installations of TeX Live on Linux and macOS using [Travis CI](https://travis-ci.org/nwhetsell/installer/builds/383213433).