### PR TITLE
Add README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# Installer of TeX Live
+
+[![Build Status](https://travis-ci.org/TeX-Live/installer.svg?branch=master)](https://travis-ci.org/TeX-Live/installer)
+[![Build status](https://ci.appveyor.com/api/projects/status/{replace this}?svg=true)](https://ci.appveyor.com/project/norbusan/installer)
+
+This is a mirror of the main TeX Live installer repository.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Installer of TeX Live
 
 [![Build Status](https://travis-ci.org/TeX-Live/installer.svg?branch=master)](https://travis-ci.org/TeX-Live/installer)
-[![Build status](https://ci.appveyor.com/api/projects/status/{replace this}?svg=true)](https://ci.appveyor.com/project/norbusan/installer)
+[![Build status](https://ci.appveyor.com/api/projects/status/ReplaceThis?svg=true)](https://ci.appveyor.com/project/norbusan/installer)
 
 This is a mirror of the main TeX Live installer repository.


### PR DESCRIPTION
This pull request adds a README.md with CI status badges and a very brief explanation of this repository.

The AppVeyor CI status badge requires a security token that’s only accessible from an AppVeyor project’s settings page. I think you can find this at https://ci.appveyor.com/project/norbusan/installer/settings/badges.