### PR TITLE
Fixed a typo that broke installation on unix

### DIFF
--- a/tlpkg/TeXLive/TLConfig.pm
+++ b/tlpkg/TeXLive/TLConfig.pm
@@ -131,7 +131,7 @@ our %FallbackDownloaderArgs = (
              '--insecure',
              '--fail', '--location', '--silent', '--output'],
   'wget' => ['--user-agent=texlive/wget', '--tries=4',
-             '--no-check-certificates',
+             '--no-check-certificate',
              "--timeout=$NetworkTimeout", '-q', '-O'],
 );
 # the way we package things on the web


### PR DESCRIPTION
There seems to be a typo added on the TLConfig.pm in commit(ceb167c5c0d496853f0112399676775fdc63b0e6).
wget does not have an option `--no-check-certificates` but has an option `--no-check-certificate`.
As a larger note, I am not sure I understand the modifications.
`--no-check-certificate` seems to be a pretty drastic option.