### PR TITLE
Allow installer to execute on Windows ARM64

### DIFF
--- a/install-tl-windows.bat
+++ b/install-tl-windows.bat
@@ -19,12 +19,16 @@ if %ver_str:~,3% == 6.0 (
   echo TeX Live 2020 has not been tested on Windows Vista.
   pause
 )
-if not "AMD64"=="%PROCESSOR_ARCHITECTURE%" (
-if not "AMD64"=="%PROCESSOR_ARCHITEW6432%" (
+for /f "usebackq skip=1 tokens=*" %%i in (`wmic OS get OSArchitecture ^| findstr /r /v "^$"`) do (
+  set "_bits=%%i"
+  rem remove spaces
+  set "_bits=!_bits: =!"
+  )
+if "%_bits%" EQU "64bits" (
   echo 32-bit no longer supported
   pause
   goto eoff
-))
+)
 
 rem version of external perl, if any. used by install-tl.
 set extperl=0

--- a/install-tl-windows.bat
+++ b/install-tl-windows.bat
@@ -24,7 +24,7 @@ for /f "usebackq skip=1 tokens=*" %%i in (`wmic OS get OSArchitecture ^| findstr
   rem remove spaces
   set "_bits=!_bits: =!"
   )
-if "%_bits%" EQU "64bits" (
+if "%_bits%" EQU "32bits" (
   echo 32-bit no longer supported
   pause
   goto eoff


### PR DESCRIPTION
When trying to install texlive on my Surface Pro X, which runs Windows ARM 64-bit with 64-bit emulation for x64 programs, the installer refuses to run as the detected architecture is of course not "AMD64". Deleting the relevant check manually in the .bat script allowed the installer to run and I now have texlive installed, and it seems to run ok so far, so unless there is some specific reason that installation on ARM64 should be prevented, it seems sensible to change the way that the bit-ness of the OS is checked. In my pull request I included one example as a suggestion, but as I unfortunately have zero experience with batch scripts, it just uses a solution I found with google. I also have no way to test if the added code works as I have no access to a 32-bit machine. But I thought it was still better to provide a proposed solution rather than just complain :)